### PR TITLE
feat: Support IOS web APP

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,13 +9,12 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <!-- 添加到主屏后显示的名字 -->
     <meta name="apple-mobile-web-app-title" content="知识记录">
-    <link rel="apple-touch-icon" href="/images/logo.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/logo.png">
     <!-- 作者信息 -->
     <meta name="author" content="unknowIfGuestInDream, liang.tang.cx@gmail.com">
     <!-- 运用docsify构建 -->
     <meta name="generator" content="docsify 4.12.0"/>
     <meta name="copyright" content="tlcsdm">
-    <meta charset="UTF-8">
     <title>知识记录</title>
     <!-- 360浏览器使用谷歌内核 -->
     <meta name="renderer" content="webkit">

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
     <meta name="google" content="notranslate"/>
     <!-- 设置浏览器图标 -->
     <link rel="icon" href="favicon.ico" type="image/x-icon"/>
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="manifest.json">
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon"/>
     <link rel=”canonical” href="https://www.tlcsdm.com"/>
     <meta name="description" content="SpringBoot2.x, SpringCloud, Java8, Linux安装软件, Extjs框架学习记录文档, antd">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <!-- 支持 iOS 添加到主屏幕为 Web App 模式 -->
+    <!-- 启用全屏运行 -->
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <!-- 控制顶部状态栏样式 -->
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <!-- 添加到主屏后显示的名字 -->
+    <meta name="apple-mobile-web-app-title" content="知识记录">
+    <link rel="apple-touch-icon" href="/images/logo.png">
     <!-- 作者信息 -->
     <meta name="author" content="unknowIfGuestInDream, liang.tang.cx@gmail.com">
     <!-- 运用docsify构建 -->
@@ -18,6 +27,7 @@
     <meta name="google" content="notranslate"/>
     <!-- 设置浏览器图标 -->
     <link rel="icon" href="favicon.ico" type="image/x-icon"/>
+    <link rel="manifest" href="/manifest.json">
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon"/>
     <link rel=”canonical” href="https://www.tlcsdm.com"/>
     <meta name="description" content="SpringBoot2.x, SpringCloud, Java8, Linux安装软件, Extjs框架学习记录文档, antd">

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "知识记录",
+  "short_name": "Docs",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#42b983",
+  "icons": [
+    {
+      "src": "/images/logo.png",
+      "sizes": "180x180",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer

- [ ] Label as either `enhancement`, `bug`, `documentation` or `style`
- [ ] Verify design and implementation

## Summary by Sourcery

Enable PWA functionality by adding a web app manifest and iOS-specific meta tags to support standalone home-screen web app installation.

New Features:
- Add manifest.json for PWA configuration including name, icons, theme, and display settings
- Update docs/index.html with Apple meta tags and apple-touch-icon to enable iOS home-screen standalone mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved support for iOS devices and Progressive Web App (PWA) capabilities, including home screen installation and full-screen mode.
  - Added a web app manifest to enable PWA installation, custom app icons, and enhanced appearance on mobile devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->